### PR TITLE
Allow setting a minimum value

### DIFF
--- a/src/MenuItems.cpp
+++ b/src/MenuItems.cpp
@@ -80,6 +80,11 @@ uint16_t MenuItem::getId() const
 	return (isInfoProgMem()) ? get_info_uint(&info->id) : info->id;
 }
 
+uint16_t MenuItem::getMinimumValue() const
+{
+	return (isInfoProgMem()) ? get_info_uint(&info->minValue) : info->minValue;
+}
+
 uint16_t MenuItem::getMaximumValue() const
 {
 	if (isMenuRuntime(this)) {
@@ -291,6 +296,9 @@ int FloatMenuItem::getDecimalPlaces() const {
 void ValueMenuItem::setCurrentValue(uint16_t val, bool silent) {
 	if (val == currentValue || val > getMaximumValue()) {
 		return;
+	}
+	if (val < getMinimumValue()) {
+		val = getMinimumValue();
 	}
 	currentValue = val;
 	changeOccurred(silent);

--- a/src/MenuItems.h
+++ b/src/MenuItems.h
@@ -50,6 +50,8 @@ struct AnyMenuInfo {
 	menuid_t id;
 	/** eeprom address for this item or -1 if not stored */
 	uint16_t eepromAddr;
+	/** minimum value that this type can store */
+	uint16_t minValue;
 	/** maximum value that this type can store */
 	uint16_t maxValue;
 	/** the callback function */
@@ -70,6 +72,8 @@ struct AnalogMenuInfo {
 	menuid_t id;
 	/** eeprom address for this item or -1 if not stored */
 	uint16_t eepromAddr;
+	/** minimum value that this type can store */
+	uint16_t minValue;
 	/** maximum value that this type can store */
 	uint16_t maxValue;
 	/** the callback function */
@@ -355,6 +359,8 @@ public:
 	uint8_t copyNameToBuffer(char* sz, int offset, int size) const;
 	/** Retrieves the ID from the info block */
 	menuid_t getId() const;
+	/** Retrieves the minimum value for this menu type */
+	uint16_t getMinimumValue() const;
 	/** Retrieves the maximum value for this menu type */
 	uint16_t getMaximumValue() const;
 	/** Retrieves the eeprom storage position for this menu (or 0xffff if not applicable) */

--- a/src/graphics/DialogRuntimeEditor.h
+++ b/src/graphics/DialogRuntimeEditor.h
@@ -22,7 +22,7 @@ class DialogMultiPartEditor : BaseDialogController {
 private:
     MenuBasedDialog *dialog;
     EditableMultiPartMenuItem* menuItemBeingEdited;
-    AnalogMenuInfo scrollingInfo = {"Item Value", nextRandomId(), 0xffff, 1, onScrollingChanged, 0, 1, "" };
+    AnalogMenuInfo scrollingInfo = {"Item Value", nextRandomId(), 0xffff, 0, 1, onScrollingChanged, 0, 1, "" };
     AnalogMenuItem scrollingEditor = AnalogMenuItem(&scrollingInfo, 0, nullptr, INFO_LOCATION_RAM);
 
 public:


### PR DESCRIPTION
This allows you to set a minimum value for an AnalogMenuItem.

**Please be aware:**
When merged, all usages of `AnyMenuInfo` and `AnalogMenuInfo` need to be changed from
`const PROGMEM AnyMenuInfo minfoX = { "Foo", ID, EEPROM, MAX, NO_CALLBACK };`
to
`const PROGMEM AnyMenuInfo minfoX = { "Foo", ID, EEPROM, MIN, MAX, NO_CALLBACK };`
So this is a breaking change.

Not 100% sure that this is the right way as it would be better to not require this parameter for `AnyMenuInfo` but only for `AnalogMenuInfo`.
But this would require another cast in `ValueMenuItem::setCurrentValue(...)`