### PR TITLE
Add support for Czech and Slovak languages

### DIFF
--- a/src/lang/language_cs.h
+++ b/src/lang/language_cs.h
@@ -1,0 +1,54 @@
+/**
+ * @file language_cs.h
+ * @brief Never include directly. contains the Czech language text for tcMenu text, controlled by TC_LOCALE.
+ */
+
+//
+// Dialog support, note: please keep ok, cancel, close and accept in lower case
+//
+
+#define TXT_DIALOG_OK "ok"
+#define TXT_DIALOG_CANCEL "storno"
+#define TXT_DIALOG_CLOSE "zavřít"
+#define TXT_DIALOG_ACCEPT "přijmout"
+
+//
+// Boolean naming options
+//
+
+#define TXT_BOOL_ON_TEXT "ZAP."
+#define TXT_BOOL_OFF_TEXT "VYP."
+#define TXT_BOOL_YES_TEXT "ANO"
+#define TXT_BOOL_NO_TEXT "NE"
+#define TXT_BOOL_TRUE_TEXT "TRUE"
+#define TXT_BOOL_FALSE_TEXT "FALSE"
+
+//
+// Touch screen text options IOA
+//
+
+#define TXT_TOUCH_CONFIGURE "Konfigurace dotyků"
+#define TXT_TOUCH_CONFIGURE_2ND "Dotkněte se zvolených oblastí"
+
+//
+// Remote Connector - pairing
+//
+
+#define TXT_PAIRING_TEXT "Čekání na párování"
+
+//
+// RemoteMenuItem dialog text for remote connections and authentication
+//
+
+#define TXT_CLOSE_CONNECTION "Uzavřít spojení"
+#define TXT_AUTH_REMOVE "Vymazat"
+#define TXT_AUTH_REMOVE_ALL_KEYS "Vymazat VŠECHNY klíče?"
+#define TXT_AUTH_EMPTY_KEY "PrázdnýKlíč"
+
+//
+// Secure menu item popup
+//
+
+#define TXT_SECURE_MENU_PROCEED "Pokračovat"
+#define TXT_SECURE_MENU_CANCEL "Storno"
+#define TXT_SECURE_PIN_WRONG "Nesprávný pin"

--- a/src/lang/language_cs_ascii.h
+++ b/src/lang/language_cs_ascii.h
@@ -1,0 +1,54 @@
+/**
+ * @file language_cs_ascii.h
+ * @brief Never include directly. contains the Czech language text for tcMenu text (ASCII only), controlled by TC_LOCALE.
+ */
+
+//
+// Dialog support, note: please keep ok, cancel, close and accept in lower case
+//
+
+#define TXT_DIALOG_OK "ok"
+#define TXT_DIALOG_CANCEL "storno"
+#define TXT_DIALOG_CLOSE "zavrit"
+#define TXT_DIALOG_ACCEPT "prijmout"
+
+//
+// Boolean naming options
+//
+
+#define TXT_BOOL_ON_TEXT "ZAP."
+#define TXT_BOOL_OFF_TEXT "VYP."
+#define TXT_BOOL_YES_TEXT "ANO"
+#define TXT_BOOL_NO_TEXT "NE"
+#define TXT_BOOL_TRUE_TEXT "TRUE"
+#define TXT_BOOL_FALSE_TEXT "FALSE"
+
+//
+// Touch screen text options IOA
+//
+
+#define TXT_TOUCH_CONFIGURE "Konfigurace dotyku"
+#define TXT_TOUCH_CONFIGURE_2ND "Dotknete se zvolenych oblasti"
+
+//
+// Remote Connector - pairing
+//
+
+#define TXT_PAIRING_TEXT "Cekani na parovani"
+
+//
+// RemoteMenuItem dialog text for remote connections and authentication
+//
+
+#define TXT_CLOSE_CONNECTION "Uzavrit spojeni"
+#define TXT_AUTH_REMOVE "Vymazat"
+#define TXT_AUTH_REMOVE_ALL_KEYS "Vymazat VSECHNY klice?"
+#define TXT_AUTH_EMPTY_KEY "PrazdnyKlic"
+
+//
+// Secure menu item popup
+//
+
+#define TXT_SECURE_MENU_PROCEED "Pokracovat"
+#define TXT_SECURE_MENU_CANCEL "Storno"
+#define TXT_SECURE_PIN_WRONG "Nespravny pin"

--- a/src/lang/language_select.h
+++ b/src/lang/language_select.h
@@ -27,6 +27,18 @@
 #else
 # include "language_fr.h"
 #endif // use ASCII
+#elif defined(TC_LOCALE_SK)
+#if defined(TC_LOCAL_ASCII)
+# include "language_sk_ascii.h"
+#else
+# include "language_sk.h"
+#endif // use ASCII
+#elif defined(TC_LOCALE_CS)
+#if defined(TC_LOCAL_ASCII)
+# include "language_cs_ascii.h"
+#else
+# include "language_cs.h"
+#endif // use ASCII
 #else
 # include "language_en.h"
 #endif

--- a/src/lang/language_sk.h
+++ b/src/lang/language_sk.h
@@ -1,0 +1,54 @@
+/**
+ * @file language_sk.h
+ * @brief Never include directly. contains the Slovak language text for tcMenu text, controlled by TC_LOCALE.
+ */
+
+//
+// Dialog support, note: please keep ok, cancel, close and accept in lower case
+//
+
+#define TXT_DIALOG_OK "ok"
+#define TXT_DIALOG_CANCEL "zrušiť"
+#define TXT_DIALOG_CLOSE "zavrieť"
+#define TXT_DIALOG_ACCEPT "prijať"
+
+//
+// Boolean naming options
+//
+
+#define TXT_BOOL_ON_TEXT "ZAP."
+#define TXT_BOOL_OFF_TEXT "VYP."
+#define TXT_BOOL_YES_TEXT "ÁNO"
+#define TXT_BOOL_NO_TEXT "NIE"
+#define TXT_BOOL_TRUE_TEXT "TRUE"
+#define TXT_BOOL_FALSE_TEXT "FALSE"
+
+//
+// Touch screen text options IOA
+//
+
+#define TXT_TOUCH_CONFIGURE "Konfigurácia dotykov"
+#define TXT_TOUCH_CONFIGURE_2ND "Dotknite sa zvolených oblastí"
+
+//
+// Remote Connector - pairing
+//
+
+#define TXT_PAIRING_TEXT "Čaká sa na párovanie"
+
+//
+// RemoteMenuItem dialog text for remote connections and authentication
+//
+
+#define TXT_CLOSE_CONNECTION "Zavrieť spojenie"
+#define TXT_AUTH_REMOVE "Vymazať"
+#define TXT_AUTH_REMOVE_ALL_KEYS "Vymazať VŠETKY kľúče?"
+#define TXT_AUTH_EMPTY_KEY "PrázdnyKľúč"
+
+//
+// Secure menu item popup
+//
+
+#define TXT_SECURE_MENU_PROCEED "Pokračovať"
+#define TXT_SECURE_MENU_CANCEL "Zrušiť"
+#define TXT_SECURE_PIN_WRONG "Nesprávny pin"

--- a/src/lang/language_sk_ascii.h
+++ b/src/lang/language_sk_ascii.h
@@ -1,0 +1,54 @@
+/**
+ * @file language_sk_ascii.h
+ * @brief Never include directly. contains the Slovak language text for tcMenu text (ASCII only), controlled by TC_LOCALE.
+ */
+
+//
+// Dialog support, note: please keep ok, cancel, close and accept in lower case
+//
+
+#define TXT_DIALOG_OK "ok"
+#define TXT_DIALOG_CANCEL "zrusit"
+#define TXT_DIALOG_CLOSE "zavriet"
+#define TXT_DIALOG_ACCEPT "prijat"
+
+//
+// Boolean naming options
+//
+
+#define TXT_BOOL_ON_TEXT "ZAP."
+#define TXT_BOOL_OFF_TEXT "VYP."
+#define TXT_BOOL_YES_TEXT "ANO"
+#define TXT_BOOL_NO_TEXT "NIE"
+#define TXT_BOOL_TRUE_TEXT "TRUE"
+#define TXT_BOOL_FALSE_TEXT "FALSE"
+
+//
+// Touch screen text options IOA
+//
+
+#define TXT_TOUCH_CONFIGURE "Konfiguracia dotykov"
+#define TXT_TOUCH_CONFIGURE_2ND "Dotknite sa zvolenych oblasti"
+
+//
+// Remote Connector - pairing
+//
+
+#define TXT_PAIRING_TEXT "Caka sa na parovanie"
+
+//
+// RemoteMenuItem dialog text for remote connections and authentication
+//
+
+#define TXT_CLOSE_CONNECTION "Zavriet spojenie"
+#define TXT_AUTH_REMOVE "Vymazat"
+#define TXT_AUTH_REMOVE_ALL_KEYS "Vymazat VSETKY kluce?"
+#define TXT_AUTH_EMPTY_KEY "PrazdnyKluc"
+
+//
+// Secure menu item popup
+//
+
+#define TXT_SECURE_MENU_PROCEED "Pokracovat"
+#define TXT_SECURE_MENU_CANCEL "Zrusit"
+#define TXT_SECURE_PIN_WRONG "Nespravny pin"


### PR DESCRIPTION
This PR adds translation for the Czech and Slovak language.

Language constants were defined as follows:
```
TC_LOCALE_SK
TC_LOCALE_SK_ASCII
TC_LOCALE_CS
TC_LOCALE_CS_ASCII
```

This was mainly to hold into international language codes which are understandable by everyone reading the code and avoid confusion. But if needed, I can rename the constants to the following constants instead:

```
TC_LOCALE_SLOVAK
TC_LOCALE_SLOVAK_ASCII
TC_LOCALE_CZECH
TC_LOCALE_CZECH_ASCII
```

Reference issues: #176 and davetcc/tcMenu#261