### PR TITLE
[i18n] Extend language_select.h

### DIFF
--- a/src/lang/language_cs.h
+++ b/src/lang/language_cs.h
@@ -1,6 +1,6 @@
 /**
  * @file language_cs.h
- * @brief Never include directly. contains the Czech language text for tcMenu text, controlled by TC_LOCALE.
+ * @brief Never include directly; contains the Czech language text for tcMenu text, controlled by TC_LOCALE.
  */
 
 //

--- a/src/lang/language_cs_ascii.h
+++ b/src/lang/language_cs_ascii.h
@@ -1,6 +1,6 @@
 /**
  * @file language_cs_ascii.h
- * @brief Never include directly. contains the Czech language text for tcMenu text (ASCII only), controlled by TC_LOCALE.
+ * @brief Never include directly; contains the Czech language text for tcMenu text (ASCII only), controlled by TC_LOCALE.
  */
 
 //

--- a/src/lang/language_de.h
+++ b/src/lang/language_de.h
@@ -1,0 +1,54 @@
+/**
+ * @file language_de.h
+ * @brief Never include directly; contains the German language text for tcMenu text, controlled by TC_LOCALE.
+ */
+
+//
+// Dialog support, note: please keep ok, cancel, close and accept in lower case
+//
+
+#define TXT_DIALOG_OK "ok"
+#define TXT_DIALOG_CANCEL "abbrechen"
+#define TXT_DIALOG_CLOSE "schließen"
+#define TXT_DIALOG_ACCEPT "akzeptieren"
+
+//
+// Boolean naming options
+//
+
+#define TXT_BOOL_ON_TEXT "EIN"
+#define TXT_BOOL_OFF_TEXT "AUS"
+#define TXT_BOOL_YES_TEXT "JA"
+#define TXT_BOOL_NO_TEXT "NEIN"
+#define TXT_BOOL_TRUE_TEXT "WAHR"
+#define TXT_BOOL_FALSE_TEXT "FALSCH"
+
+//
+// Touch screen text options IOA
+//
+
+#define TXT_TOUCH_CONFIGURE "Touch-Konfiguration"
+#define TXT_TOUCH_CONFIGURE_2ND "Berühren Sie ausgewählte Bereiche"
+
+//
+// Remote Connector - pairing
+//
+
+#define TXT_PAIRING_TEXT "Pairing warten"
+
+//
+// RemoteMenuItem dialog text for remote connections and authentication
+//
+
+#define TXT_CLOSE_CONNECTION "Verbindung schließen"
+#define TXT_AUTH_REMOVE "Entfernen"
+#define TXT_AUTH_REMOVE_ALL_KEYS "ALLE Schlüssel entfernen?"
+#define TXT_AUTH_EMPTY_KEY "LeererSchlüssel"
+
+//
+// Secure menu item popup
+//
+
+#define TXT_SECURE_MENU_PROCEED "Fortfahren"
+#define TXT_SECURE_MENU_CANCEL "Abbrechen"
+#define TXT_SECURE_PIN_WRONG "Pin inkorrekt"

--- a/src/lang/language_de_ascii.h
+++ b/src/lang/language_de_ascii.h
@@ -1,0 +1,54 @@
+/**
+ * @file language_de_ascii.h
+ * @brief Never include directly; contains the German language text for tcMenu text (ASCII only), controlled by TC_LOCALE.
+ */
+
+//
+// Dialog support, note: please keep ok, cancel, close and accept in lower case
+//
+
+#define TXT_DIALOG_OK "ok"
+#define TXT_DIALOG_CANCEL "abbrechen"
+#define TXT_DIALOG_CLOSE "schliessen"
+#define TXT_DIALOG_ACCEPT "akzeptieren"
+
+//
+// Boolean naming options
+//
+
+#define TXT_BOOL_ON_TEXT "EIN"
+#define TXT_BOOL_OFF_TEXT "AUS"
+#define TXT_BOOL_YES_TEXT "JA"
+#define TXT_BOOL_NO_TEXT "NEIN"
+#define TXT_BOOL_TRUE_TEXT "WAHR"
+#define TXT_BOOL_FALSE_TEXT "FALSCH"
+
+//
+// Touch screen text options IOA
+//
+
+#define TXT_TOUCH_CONFIGURE "Touch-Konfiguration"
+#define TXT_TOUCH_CONFIGURE_2ND "Beruehren Sie ausgewaehlte Bereiche"
+
+//
+// Remote Connector - pairing
+//
+
+#define TXT_PAIRING_TEXT "Pairing warten"
+
+//
+// RemoteMenuItem dialog text for remote connections and authentication
+//
+
+#define TXT_CLOSE_CONNECTION "Verbindung schliessen"
+#define TXT_AUTH_REMOVE "Entfernen"
+#define TXT_AUTH_REMOVE_ALL_KEYS "ALLE Schluessel entfernen?"
+#define TXT_AUTH_EMPTY_KEY "LeererSchluessel"
+
+//
+// Secure menu item popup
+//
+
+#define TXT_SECURE_MENU_PROCEED "Fortfahren"
+#define TXT_SECURE_MENU_CANCEL "Abbrechen"
+#define TXT_SECURE_PIN_WRONG "Pin inkorrekt"

--- a/src/lang/language_en.h
+++ b/src/lang/language_en.h
@@ -1,6 +1,6 @@
 /**
  * @file language_en.h
- * @brief Never include directly. contains the English language text for tcMenu text, controlled by TC_LOCALE, this is the default (EN).
+ * @brief Never include directly; contains the English language text for tcMenu text, controlled by TC_LOCALE, this is the default (EN).
  */
 
 //

--- a/src/lang/language_fr.h
+++ b/src/lang/language_fr.h
@@ -1,6 +1,6 @@
 /**
  * @file language_fr.h
- * @brief Never include directly. contains the French language text for tcMenu text, controlled by TC_LOCALE.
+ * @brief Never include directly; contains the French language text for tcMenu text, controlled by TC_LOCALE.
  */
 
 //

--- a/src/lang/language_fr_ascii.h
+++ b/src/lang/language_fr_ascii.h
@@ -1,6 +1,6 @@
 /**
  * @file language_fr.h
- * @brief Never include directly. contains the French language text for tcMenu text (ASCII only), controlled by TC_LOCALE.
+ * @brief Never include directly; contains the French language text for tcMenu text (ASCII only), controlled by TC_LOCALE.
  */
 
 //

--- a/src/lang/language_select.h
+++ b/src/lang/language_select.h
@@ -21,19 +21,21 @@
 
 #if __has_include(<project_locale.h>)
 # include <project_locale.h>
-#elif defined(TC_LOCALE_FR)
+#elif defined(TC_LOCALE_FR) || defined(TC_LOCALE_FR_BE) \
+ || defined(TC_LOCALE_FR_CA) || defined(TC_LOCALE_FR_FR) \
+ || defined(TC_LOCALE_FR_LU) || defined(TC_LOCALE_FR_CH)
 #if defined(TC_LOCAL_ASCII)
 # include "language_fr_ascii.h"
 #else
 # include "language_fr.h"
 #endif // use ASCII
-#elif defined(TC_LOCALE_SK)
+#elif defined(TC_LOCALE_SK) || defined(TC_LOCALE_SK_SK)
 #if defined(TC_LOCAL_ASCII)
 # include "language_sk_ascii.h"
 #else
 # include "language_sk.h"
 #endif // use ASCII
-#elif defined(TC_LOCALE_CS)
+#elif defined(TC_LOCALE_CS) || defined(TC_LOCALE_CS_CZ)
 #if defined(TC_LOCAL_ASCII)
 # include "language_cs_ascii.h"
 #else

--- a/src/lang/language_select.h
+++ b/src/lang/language_select.h
@@ -1,6 +1,6 @@
 /**
  * @file language_select.h
- * @brief contains the logic to select the right language entries for internal tcMenu library strings at compile time
+ * @brief contains the logic to select the right language entries for internal tcMenu library strings at compile time.
  */
 
 #ifndef TCLIBRARYDEV_LANGUAGE_SELECT_H
@@ -9,7 +9,7 @@
 //
 // The highest precedence is to add `project_locale.h` if your build chain supports it. English is the default
 //
-// PlatformIO/full build systems -  for French ASCII as an example -DTC_LOCALE_FRENCH -DTC_LOCAL_ASCII
+// PlatformIO/full build systems - for French ASCII as an example -DTC_LOCALE_FR -DTC_LOCAL_ASCII
 //
 // If you're using original Arduino IDE you can force a definition of TC_LOCALE here. Commented out example below.
 // For example if we wanted french with only ASCII (32..126)
@@ -28,6 +28,14 @@
 # include "language_fr_ascii.h"
 #else
 # include "language_fr.h"
+#endif // use ASCII
+#elif defined(TC_LOCALE_DE) || defined(TC_LOCALE_DE_AT) \
+ || defined(TC_LOCALE_DE_DE) || defined(TC_LOCALE_DE_LU) \
+ || defined(TC_LOCALE_DE_CH)
+#if defined(TC_LOCAL_ASCII)
+# include "language_de_ascii.h"
+#else
+# include "language_de.h"
 #endif // use ASCII
 #elif defined(TC_LOCALE_SK) || defined(TC_LOCALE_SK_SK)
 #if defined(TC_LOCAL_ASCII)

--- a/src/lang/language_sk.h
+++ b/src/lang/language_sk.h
@@ -1,6 +1,6 @@
 /**
  * @file language_sk.h
- * @brief Never include directly. contains the Slovak language text for tcMenu text, controlled by TC_LOCALE.
+ * @brief Never include directly; contains the Slovak language text for tcMenu text, controlled by TC_LOCALE.
  */
 
 //

--- a/src/lang/language_sk_ascii.h
+++ b/src/lang/language_sk_ascii.h
@@ -1,6 +1,6 @@
 /**
  * @file language_sk_ascii.h
- * @brief Never include directly. contains the Slovak language text for tcMenu text (ASCII only), controlled by TC_LOCALE.
+ * @brief Never include directly; contains the Slovak language text for tcMenu text (ASCII only), controlled by TC_LOCALE.
  */
 
 //


### PR DESCRIPTION
## Overview
- Translate TcMenu strings into German.
- Add checks for all language variants of a given language.

## Rationale
In TcMenu, it is possible to add a locale in the form `lang_country`.
Based on that, TcMenu generates flag like `TC_LOCALE_FR_FR`.
However, it won't match the definition of `TC_LOCALE_FR` and will
fallback to `TC_LOCALE_EN` despite having a better translation
available.

We're defining all possible language variants so that the proper
locale is selected in all circumstances. Because we're
using preprocessor directives, there is no impact on the
app performance.

This patch simplifies the build environment. Instead of configuration like this:

```ini
build_flags =
    -D TC_LOCALE_CS_CZ
    -D TC_LOCALE_CS
```

We can use either of these:

```ini
build_flags =
    -D TC_LOCALE_CS_CZ
```

```ini
build_flags =
    -D TC_LOCALE_CS
```